### PR TITLE
Update .NET Core version to 3.1

### DIFF
--- a/secretapp/secretapp.csproj
+++ b/secretapp/secretapp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The tutorial asks the users to install dotnet-sdk-3.1. The dotnet run command will error out without this change.